### PR TITLE
Test on GitHub Actions using tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: pip
+          cache-dependency-path: setup.py
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U tox
+
+      - name: Tox tests
+        run: |
+          tox -e py

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,7 @@ setup(
     #data_files=[('docs', ['docs'])],
     # Exclude the tests from being installed to site-packages
     exclude_package_data={'': ['tests']},
+    extras_require={
+        "tests": ["pytest", "pytest-cov"],
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{py3, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39, 38}
 
 [testenv]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+requires =
+    tox>=4.2
+env_list =
+    py{py3, 312, 311, 310, 39, 38}
+
+[testenv]
+extras =
+    tests
+pass_env =
+    FORCE_COLOR
+commands =
+    {envpython} -m pytest \
+      --cov chunkmuncher \
+      --cov tests \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
+      {posargs}


### PR DESCRIPTION
This adds CI to the project.

When a PR is opened, it will run the tests on a matrix of Python 3.8-3.12 and PyPy 3.10, on Ubuntu, Windows and macOS.

This means we can ensure tests pass before merging PRs.

It also adds tox config for testing on the CI, and is also useful locally testing multiple Python versions, if you have them installed.

For example:

```sh
pip install tox
tox -e py312 # Test Python 3.12
tox -e py38  # Test Python 3.8
tox          # Test all available
tox -p auto  # Test all available, in parallel
```

# Demo

https://github.com/hugovk/ChunkMuncher/actions/runs/7044089563

![image](https://github.com/jscuster/ChunkMuncher/assets/1324225/2627ec2f-b14c-4d62-995b-daef039ecfaf)


